### PR TITLE
fix to support github style short dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ module.exports = function checkPath(basePath) {
                 base = path.dirname(base)
             }
             if (/#/.test(expectedVersion) || /^(http|git)/.test(expectedVersion)) {
+                expectedVersion = expectedVersion.replace(/^git\+https/, 'git')
                 if (dependency._from && dependency._from.indexOf(expectedVersion) < 0) {
                     fail(packageJson, dependencyName, dependencyPath, expectedVersion, dependency._from)
                 }


### PR DESCRIPTION
When a dependency of the form "username/repo#commit" is used as a
dependency of a module, npm expands this to
"git+https://github.com/username/repo#commit" in the dependencies list
in package.json but the `_from` value in that dependencies package.json
just has "git://github.com" causing the two values to mismatch when in
fact they are the same.

This commit simply fixes up the git+https:// url to just be git:// so
the two urls match.
