### PR TITLE
Handle version #s with leading 0s

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,11 @@ module.exports = function checkPath(basePath) {
             var base = basePath
             var dependencyPath
             var dependency
+
+            //modification of http://stackoverflow.com/questions/24315535/remove-leading-zeros-of-a-string-in-javascript
+            //See: https://github.com/marcello3d/node-safestart/issues/4
+            var truncatedVersion = expectedVersion.replace(/\b0+(?=[0-9]+)/g, '')
+
             while (true) {
                 dependencyPath = path.join(base, 'node_modules', dependencyName)
                 dependency = checkPath(dependencyPath)
@@ -43,7 +48,7 @@ module.exports = function checkPath(basePath) {
                 if (dependency._from && dependency._from.indexOf(expectedVersion) < 0) {
                     fail(packageJson, dependencyName, dependencyPath, expectedVersion, dependency._from)
                 }
-            } else if (!/latest/.test(expectedVersion) && !semver.satisfies(dependency.version, expectedVersion)) {
+            } else if (!/latest/.test(expectedVersion) && !semver.satisfies(dependency.version, expectedVersion) && !semver.satisfies(dependency.version, truncatedVersion)) {
                 fail(packageJson, dependencyName, dependencyPath, expectedVersion, dependency.version)
             }
         })

--- a/package.json
+++ b/package.json
@@ -1,26 +1,31 @@
 {
-    "name": "safestart",
-    "version": "0.3.1",
-    "description": "Checks if everything is up to date",
-    "main": "index.js",
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/marcello3d/node-safestart.git"
-    },
-    "engines" : {
-        "node" : ">=0.8"
-    },
-    "dependencies": {
-        "semver": "~2.2.1"
-    },
-    "bin": {
-        "safestart": "./bin/safestart"
-    },
-    "scripts": {
-        "test": "node test/self.js"
-    },
-    "keywords": [ "npm", "dependencies", "node_modules", "package.json" ],
-    "author": "Marcello Bastéa-Forte <marcello@cellosoft.com>",
-    "license": "zlib",
-    "readmeFilename": "Readme.md"
+  "name": "safestart",
+  "version": "0.3.2",
+  "description": "Checks if everything is up to date",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/marcello3d/node-safestart.git"
+  },
+  "engines": {
+    "node": ">=0.8"
+  },
+  "dependencies": {
+    "semver": "~4.2.0"
+  },
+  "bin": {
+    "safestart": "./bin/safestart"
+  },
+  "scripts": {
+    "test": "node test/self.js"
+  },
+  "keywords": [
+    "npm",
+    "dependencies",
+    "node_modules",
+    "package.json"
+  ],
+  "author": "Marcello Bastéa-Forte <marcello@cellosoft.com>",
+  "license": "zlib",
+  "readmeFilename": "Readme.md"
 }


### PR DESCRIPTION
This fixes issue #4 
- Bumped `semver` to be current
- Added in regex to remove leading 0s in package versions (see: https://github.com/mojombo/semver/issues/112)

I tested by briefly including `react` into `package.json`, which would fail due to an expected version of `7001.0001.0000-dev-harmony-fb` (acutal being `7001.1.0-dev-harmony-fb` when pulled from `npm`).

Changes fixed the issue.
