### PR TITLE
use git, http logic for filesystem locations

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ function scanDependencies(packageJson, basePath, dependencies, required) {
             }
             base = path.dirname(base)
         }
-        if (/#/.test(expectedVersion) || /^(http|git)/.test(expectedVersion)) {
+        if (/#/.test(expectedVersion) || /^(http|git|file:)/.test(expectedVersion)) {
             if (!dependency._resolved) {
                 return;
             }


### PR DESCRIPTION
This change allows `package.json` entries like:

```
    "fubar": "file:../../fubar",
```