### PR TITLE
Update node package semver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: node_js
 node_js:
     - "0.8"
     - "0.10"
+after_script:
+    - npm run scan_packages

--- a/Readme.md
+++ b/Readme.md
@@ -18,6 +18,16 @@ Can also be used commandline:
 safestart
 ```
 
+Development
+-----------
+
+When developing, be sure to test the package and also check the dependencies are free of CVEs.
+
+```bash
+npm run test
+npm run scan_packages
+```
+
 License
 -------
 Open source software under the [zlib license](LICENSE).

--- a/package.json
+++ b/package.json
@@ -12,13 +12,14 @@
   },
   "dependencies": {
     "normalize-git-url": "1.0.1",
-    "semver": "4.2.0"
+    "semver": "4.3.6"
   },
   "bin": {
     "safestart": "./bin/safestart"
   },
   "scripts": {
-    "test": "mocha --ui bdd --reporter spec --bail --check-leaks -- test/*.js"
+    "test": "mocha --ui bdd --reporter spec --bail --check-leaks -- test/*.js",
+    "scan_packages": "nsp check"
   },
   "keywords": [
     "npm",
@@ -30,6 +31,7 @@
   "license": "zlib",
   "readmeFilename": "Readme.md",
   "devDependencies": {
-    "mocha": "2.2.5"
+    "mocha": "2.2.5",
+    "nsp": "2.6.1"
   }
 }


### PR DESCRIPTION
There is [a CVE](https://nodesecurity.io/advisories/31) for semver 4.2.0 (really it is for < 4.3.3) and so this PR updates to version 4.3.6.

Also updated the README to include the commands to run tests and checks for CVEs in dependencies.